### PR TITLE
Allows for a minimal username length of 2 instead of 3

### DIFF
--- a/src/arch/user
+++ b/src/arch/user
@@ -62,7 +62,7 @@ _get_user_variables() {
     echo
 
     # Username
-    until [[ ${#USER_NAME} -ge 3 && ${USER_NAME} \
+    until [[ ${#USER_NAME} -ge 2 && ${USER_NAME} \
 =~ ^[a-zA-Z0-9][-a-zA-Z0-9_]+$ ]]; do
         _prompt "Enter username:" "(e.g., johnny)"
         read -r USER_NAME


### PR DESCRIPTION
Some people (me included) like to use the username 'me', which requires the minimal username length to be 2 characters instead of 3