### PR TITLE
LVM on LUKS tests

### DIFF
--- a/src/arch/partitioning
+++ b/src/arch/partitioning
@@ -117,7 +117,7 @@ _default_partitioning_scheme() {
     partprobe "${DRIVE}" && sleep 1
 
     ### Logical Volume Manager ? (UEFI only)
-    #_get_lvm_and_luks
+    _get_lvm_and_luks
 
     ### Get optional partitions (swap, home)
     _get_user_partitions


### PR DESCRIPTION
 Need UEFI system testers. 

To use `dev` version run `wget tiny.cc/archboot-dev; sh archboot-dev` 